### PR TITLE
Fix battle log init

### DIFF
--- a/main.py
+++ b/main.py
@@ -597,10 +597,17 @@ class BrawlStarsApp:
         """Displays battle logs for both players side by side"""
         player1_name = self._get_player_name(player1_tag)
         player2_name = self._get_player_name(player2_tag)
-        
+
+        # Ensure variables exist even if battle logs are missing
+        formatted_battles1 = []
+        formatted_battles2 = []
+        star_count1 = 0
+        star_count2 = 0
+
         # Trophy Progress Chart
         st.write("### Trophy Progression in Recent Games")
-        
+        if not battles1 or not battles2:
+            st.info("Battle logs not available for one or both players.")
         if battles1 and battles2:
             # Process battle data for player 1
             formatted_battles1, star_count1 = self.data_processor.format_battle_log(battles1, player1_tag)


### PR DESCRIPTION
## Summary
- prevent errors when battle logs are missing by initializing `formatted_battles*` and star counts
- show an info message if battle logs are not available

## Testing
- `python -m py_compile api_client.py data_processor.py main.py ui_components.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684068f5b680832c8a4557e1871b99dc